### PR TITLE
add .gitignore to sources_1/ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ thinpad_top.runs/
 /.lint/
 /.Xil
 /.Xilinx
+*.str

--- a/thinpad_top.srcs/sources_1/ip/.gitignore
+++ b/thinpad_top.srcs/sources_1/ip/.gitignore
@@ -1,0 +1,3 @@
+*.*
+!*.xci
+!.gitignore


### PR DESCRIPTION
keep `.xci` of IP cores only, other files can be regenerated